### PR TITLE
Update app.py Fixing error with lmstudio don´t know token and model

### DIFF
--- a/streamlit-streaming-langchain/app.py
+++ b/streamlit-streaming-langchain/app.py
@@ -15,19 +15,22 @@ st.set_page_config(page_title="LM Studio Streaming Chatbot", page_icon="🤖")
 st.title("LM Studio Streaming Chatbot")
 
 def get_response(user_query, chat_history):
-
     template = """
-    You are a helpful assistant. Use the chat history if it helps, otherwise ignore it:
+    You are a helpful assistant. Answer the following questions considering the history of the conversation:
 
     Chat history: {chat_history}
 
-    User response: {user_question}
+    User question: {user_question}
     """
 
     prompt = ChatPromptTemplate.from_template(template)
 
-    # Using LM Studio Local Inference Server
-    llm = ChatOpenAI(base_url="http://localhost:1234/v1")
+    # Modified line: Add model parameter matching your local model
+    llm = ChatOpenAI(
+        base_url="http://localhost:1234/v1",
+        api_key="not-needed",
+        model="llama-3.2-1b-instruct"  # Match your local model name
+    )
 
     chain = prompt | llm | StrOutputParser()
     


### PR DESCRIPTION
**Title:** Missing Token and Model Name Arguments in LM Studio Inference Server Example  

**Description:**  

While following the steps in your post [“Streaming Local LLM Responses with LM Studio Inference Server”](https://medium.com/@ingridwickstevens/streaming-local-llm-responses-with-lm-studio-inference-server-cce3f78b2522), I encountered two issues:  

1. The script requires an API token, but none is provided. A placeholder like `"not-needed"` resolves this.  
2. The model name argument is missing, which prevents the script from running unless explicitly specified.  

### **Proposed Fix:**  

Adding the `api_key` and `model` arguments to `ChatOpenAI`:  

```python
llm = ChatOpenAI(
    base_url="http://localhost:1234/v1",
    api_key="not-needed",
    model="llama-3.2-1b-instruct"  # Match your local model name
)
```

This ensures compatibility with the latest LM Studio version.  

**Related GitHub Issue:** [ingridstevens/AI-projects#2](https://github.com/ingridstevens/AI-projects/issues/2)  

Hope this helps! 🚀  
